### PR TITLE
Fixed go get build error

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<span style="display: inline-block;">
+[![Go Report Card](https://goreportcard.com/badge/github.com/clearthesky/httpparse)](https://goreportcard.com/report/github.com/clearthesky/httpparse)
+</span>
+
 Parse and display http traffic from network device or pcap file. This is a go version of origin pcap-parser, thanks to gopacket project, this tool has simpler code base and is more efficient.
 
 For origin python implementation, [go to this branch](https://github.com/clearthesky/httpparse/tree/pcap-parser-python).

--- a/tcp_assembly.go
+++ b/tcp_assembly.go
@@ -6,7 +6,6 @@ import (
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/layers"
 	"io"
-	"reflect"
 	"strconv"
 	"sync"
 	"time"


### PR DESCRIPTION
Fix go get error

eproydakov@eproydakov-HP-ZBook:~/repository$ go get github.com/clearthesky/httpparse
# github.com/clearthesky/httpparse
../../gopath/src/github.com/clearthesky/httpparse/tcp_assembly.go:9: imported and not used: "reflect"
